### PR TITLE
feat: Use dcurl shared library from JAR file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Variables
 ROCKSDB_VERSION=5.18.1
+DCURL_VERSION=0.2.0
 
 .PHONY: all dcurl rocksdb iri check
 
@@ -10,6 +11,13 @@ dcurl:
 	git submodule update --init $@
 	# FIXME: support other architecture rather than x86_64
 	$(MAKE) -C $@ BUILD_AVX=1 BUILD_JNI=1
+	# install
+	mvn install:install-file \
+	-DgroupId=org.dltcollab \
+	-DartifactId=dcurljni \
+	-Dversion=${DCURL_VERSION} \
+	-Dfile=$@/build/dcurljni-${DCURL_VERSION}.jar \
+	-Dpackaging=jar
 
 rocksdb:
 	git submodule update --init $@
@@ -27,6 +35,6 @@ iri:
 	mvn -q clean && \
 	mvn -q package -Dmaven.test.skip
 
-check: rocksdb
+check: dcurl rocksdb
 	mvn -q clean && \
 	mvn integration-test -Dlogging-level=INFO

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
             <version>5.18.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.dltcollab</groupId>
+            <artifactId>dcurljni</artifactId>
+            <version>0.2.0</version>
+        </dependency>
+
         <!-- json support -->
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/iota/iri/crypto/PearlDiver.java
+++ b/src/main/java/com/iota/iri/crypto/PearlDiver.java
@@ -2,6 +2,9 @@ package com.iota.iri.crypto;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.dltcollab.Dcurl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Proof of Work calculator.
@@ -21,6 +24,7 @@ public class PearlDiver {
         COMPLETED
     }
 
+    private static final Logger log = LoggerFactory.getLogger(PearlDiver.class);
     private static final int TRANSACTION_LENGTH = 8019;
 
     private static final int CURL_HASH_LENGTH = 243;
@@ -36,12 +40,19 @@ public class PearlDiver {
 
     public static void init(String exlibName) {
         try {
-            System.loadLibrary(exlibName);
+            try {
+                System.loadLibrary(exlibName);
+            } catch (java.lang.UnsatisfiedLinkError e) {
+                if (exlibName.equals("dcurl")) {
+                    Dcurl dcurl = new Dcurl();
+                    dcurl.loadLibraryFromJar();
+                }
+            }
             if (PearlDiver.exlibInit()) {
                 isExternal = true;
             }
         } catch (java.lang.UnsatisfiedLinkError e) {
-            /* Do Nothing */
+            log.info("No external library for {}", PearlDiver.class.getSimpleName());
         }
     }
 


### PR DESCRIPTION
# Description

The dcurl submodule is updated to support generating dcurl JAR file
and the Makefile can install the JAR file like rocksdb does.

The priority to load the shared library:
1. Search from the java.library.path and load it. (Deprecated)
2. Load from the installed JAR file.

If the dcurl library is unable to use, the IRI prints out the
information that there is no external library for PearlDiver.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Use the command
`$ java -jar target/iri-[version]-COACH-[commit-ID].jar --pearldiver-exlib dcurl`

# Checklist:

- [X] I have performed a self-review of my own code