### PR TITLE
perf: Parallelize attachToTangle API again

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -584,7 +584,7 @@ public class API {
       * @return {@link com.iota.iri.service.dto.GetTransactionsToApproveResponse}
       **/
     @Document(name="getTransactionsToApprove")
-    private synchronized AbstractResponse getTransactionsToApproveStatement(int depth, Optional<Hash> reference) {
+    private AbstractResponse getTransactionsToApproveStatement(int depth, Optional<Hash> reference) {
         if (depth < 0 || depth > configuration.getMaxDepth()) {
             return ErrorResponse.create("Invalid depth input");
         }


### PR DESCRIPTION
With new network refacotring in v1.8.0, the queue problem seems resolve.
So we roll back implementaion of parallel gTTA again.