### PR TITLE
Fix travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
 
 matrix:
   allow_failures:
+    - jdk: openjdk8
     - jdk: oraclejdk9
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ matrix:
   allow_failures:
     - jdk: oraclejdk9
 
-install:
- - make rocksdb
-
 script:
   #run tests and integration tests
   # see  https://stackoverflow.com/questions/34405047/how-do-you-merge-into-another-branch-using-travis-with-git-commands?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa


### PR DESCRIPTION
# Description

Fix travis CI.
Add the **OpenJDK8** CI testing into `allow_failures` case.

In Travis CI Trusty environment, using OpenJDK8 has a bug that it uses
Java 8 Runtime Environment with javac 9.
Hence the rocksdb part would fail with the version mismatching.

Bug reference:
travis-ci/travis-ci#9867

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
